### PR TITLE
Change default template

### DIFF
--- a/postgresql/_database.sls
+++ b/postgresql/_database.sls
@@ -26,7 +26,9 @@ postgresql_database_{{ svr_name|default('localhost') }}_{{ database_name }}:
     - name: {{ database.get('name', database_name) }}
     - encoding: {{ database.encoding }}
     - user: postgres
-    - template: template0
+    {%- if database.template is defined %}
+    - template: {{ database.template }}
+    {%- endif %}
     - owner: {% for user in database.users %}{% if loop.first %}{{ user.name }}{% endif %}{% endfor %}
     - require:
         {%- for user in database.users %}


### PR DESCRIPTION
`template1` is used by default for new databases. This allows to setup some default options (extensions for example) for future use by other databases. 