### PR TITLE
Add support for simple queries

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -296,6 +296,11 @@ Client
                   host: localhost
                   createdb: true
                   rights: all privileges
+                init:
+                  maintenance_db: mydb
+                  queries:
+                  - INSERT INTO login VALUES (11, 1) ;
+                  - INSERT INTO device VALUES (1, 11, 42);
 
 
 Sample usage

--- a/postgresql/_database.sls
+++ b/postgresql/_database.sls
@@ -39,6 +39,24 @@ postgresql_database_{{ svr_name|default('localhost') }}_{{ database_name }}:
     - user: root
     {%- endif %}
 
+{%- if database.init is defined %}
+{%- for query in database.init.get('queries', []) %}
+{% set maintenance_db = database.init.get('maintenance_db', database_name) %}
+postgresql_database_{{ svr_name|default('localhost') }}_{{ maintenance_db }}_{{ loop.index }}:
+  cmd.run:
+    - name: "psql -h {{ admin.get('host', 'localhost') }} \
+             -U {{ admin.get('user', 'root') }} \
+             -d {{ maintenance_db }} \
+             -c \"{{ query }} \" "
+      env: 
+        PGPASSWORD: {{ admin.get('password', '') }}
+      {%- if not database.init.get('force', false) == true %}
+      onchanges: 
+        - postgres_database: postgresql_database_{{ svr_name|default('localhost') }}_{{ maintenance_db }}
+      {%- endif %}
+{%- endfor %}
+{%- endif %}
+
 {%- if database.initial_data is defined %}
 
 {%- set engine = database.initial_data.get("engine", "backupninja") %}


### PR DESCRIPTION
Allows executing of the simple queries. This approach can be used for initialization database with required data. Example of use:

```
postgresql:
  client:
    server:
      server01:
        admin:
          host: database.host
          port: 5432
          user: root
          password: password
        database:
          mydb:
            enabled: true
            encoding: 'UTF8'
            locale: 'en_US'
            users:
            - name: test
              password: test
              host: localhost
              createdb: true
              rights: all privileges
            init:
              maintenance_db: pushkin
              queries:
                - INSERT INTO login VALUES (11, 1) ;
                - INSERT INTO device VALUES (1, 11, 42);

```