### PR TITLE
Fix `bind.address` parameter

### DIFF
--- a/postgresql/files/8.4/postgresql.conf.Debian
+++ b/postgresql/files/8.4/postgresql.conf.Debian
@@ -59,7 +59,7 @@ external_pid_file = '/var/run/postgresql/8.4-main.pid'		# write an extra PID fil
 {%- if server.bind.address == '0.0.0.0' %}
 listen_addresses = '*'
 {%- else %}
-listen_addresses = 'localhost'{% if server.bind.address != '127.0.0.1' %}, '{{ bind.address }}'{% endif %}
+listen_addresses = 'localhost'{% if server.bind.address != '127.0.0.1' %}, '{{ server.bind.address }}'{% endif %}
 {%- endif %}
 port = {{ server.bind.get('port', '5432') }}
 max_connections = 100

--- a/postgresql/files/9.1/postgresql.conf.Debian
+++ b/postgresql/files/9.1/postgresql.conf.Debian
@@ -59,7 +59,7 @@ external_pid_file = '/var/run/postgresql/9.1-main.pid'		# write an extra PID fil
 {%- if server.bind.address == '0.0.0.0' %}
 listen_addresses = '*'
 {%- else %}
-listen_addresses = 'localhost'{% if server.bind.address != '127.0.0.1' %}, '{{ bind.address }}'{% endif %}
+listen_addresses = 'localhost'{% if server.bind.address != '127.0.0.1' %}, '{{ server.bind.address }}'{% endif %}
 {%- endif %}
 port = {{ server.bind.get('port', '5432') }}
 max_connections = 100

--- a/postgresql/files/9.3/postgresql.conf.Debian
+++ b/postgresql/files/9.3/postgresql.conf.Debian
@@ -60,7 +60,7 @@ external_pid_file = '/var/run/postgresql/9.3-main.pid'			# write an extra PID fi
 {%- if server.bind.address == '0.0.0.0' %}
 listen_addresses = '*'
 {%- else %}
-listen_addresses = 'localhost'{% if server.bind.address != '127.0.0.1' %}, '{{ bind.address }}'{% endif %}
+listen_addresses = 'localhost'{% if server.bind.address != '127.0.0.1' %}, '{{ server.bind.address }}'{% endif %}
 {%- endif %}
 port = {{ server.bind.get('port', '5432') }}
 max_connections = 100			# (change requires restart)

--- a/postgresql/files/9.5/postgresql.conf.Debian
+++ b/postgresql/files/9.5/postgresql.conf.Debian
@@ -59,7 +59,7 @@ external_pid_file = '/var/run/postgresql/9.5-main.pid'			# write an extra PID fi
 {%- if server.bind.address == '0.0.0.0' %}
 listen_addresses = '*'
 {%- else %}
-listen_addresses = 'localhost'{% if server.bind.address != '127.0.0.1' %}, '{{ bind.address }}'{% endif %}
+listen_addresses = 'localhost'{% if server.bind.address != '127.0.0.1' %}, '{{ server.bind.address }}'{% endif %}
 {%- endif %}
 port = {{ server.bind.get('port', '5432') }}
 #listen_addresses = 'localhost'		# what IP address(es) to listen on;


### PR DESCRIPTION
`bind.address` parameter is missing `server.` prefix in some conf files which
causes error when rendering template with other bind address than
`0.0.0.0` or `127.0.0.1`.