### PR TITLE
Fixes for Salt 2019.2.0 / Python 3

### DIFF
--- a/postgresql/_database.sls
+++ b/postgresql/_database.sls
@@ -68,25 +68,6 @@ postgresql_database_{{ svr_name|default('localhost') }}_{{ database_name }}_{{ m
 {%- endfor %}
 {%- endif %}
 
-{%- for name, extension in database.get('extension', {}).items() %}
-postgresql_database_{{ svr_name|default('localhost') }}_{{ database_name }}_{{ name }}:
-  {%- if extension.get('enabled', true) %}
-  postgres_extension.present:
-    - schema: {{ extension.get('schema', 'public') }}
-  {%- else %}
-  postgres_extension.absent:
-  {%- endif %}
-    - name: {{ name }}
-    - maintenance_db: {{ database_name }}
-    - user: root
-    {%- if admin is defined %}
-    {%- for k, p in admin.items() %}
-    - db_{{ k }}: {{ p }}
-    {%- endfor %}
-    - user: root
-    {%- endif %}
-{%- endfor %}
-
 {%- if database.initial_data is defined %}
 
 {%- set engine = database.initial_data.get("engine", "backupninja") %}

--- a/postgresql/_database.sls
+++ b/postgresql/_database.sls
@@ -15,7 +15,7 @@ postgresql_user_{{ svr_name|default('localhost') }}_{{ database_name }}_{{ user.
         - service: postgresql_service
     {%- endif %}
     {%- if admin is defined %}
-    {%- for k, p in admin.iteritems() %}
+    {%- for k, p in admin.items() %}
     - db_{{ k }}: {{ p }}
     {%- endfor %}
     - user: root
@@ -39,7 +39,7 @@ postgresql_database_{{ svr_name|default('localhost') }}_{{ database_name }}:
         - postgres_user: postgresql_user_{{ svr_name|default('localhost') }}_{{ database_name }}_{{ user.name }}
         {%- endfor %}
     {%- if admin is defined %}
-    {%- for k, p in admin.iteritems() %}
+    {%- for k, p in admin.items() %}
     - db_{{ k }}: {{ p }}
     {%- endfor %}
     - user: root
@@ -68,7 +68,7 @@ postgresql_database_{{ svr_name|default('localhost') }}_{{ database_name }}_{{ m
 {%- endfor %}
 {%- endif %}
 
-{%- for name, extension in database.get('extension', {}).iteritems() %}
+{%- for name, extension in database.get('extension', {}).items() %}
 postgresql_database_{{ svr_name|default('localhost') }}_{{ database_name }}_{{ name }}:
   {%- if extension.get('enabled', true) %}
   postgres_extension.present:
@@ -80,7 +80,7 @@ postgresql_database_{{ svr_name|default('localhost') }}_{{ database_name }}_{{ n
     - maintenance_db: {{ database_name }}
     - user: root
     {%- if admin is defined %}
-    {%- for k, p in admin.iteritems() %}
+    {%- for k, p in admin.items() %}
     - db_{{ k }}: {{ p }}
     {%- endfor %}
     - user: root

--- a/postgresql/_database.sls
+++ b/postgresql/_database.sls
@@ -61,10 +61,10 @@ postgresql_database_{{ svr_name|default('localhost') }}_{{ database_name }}_{{ m
         PGPASSWORD: {{ admin.get('password', '') }}
       {%- if not database.init.get('force', false) == true %}
       onchanges:
-        - postgres_database: postgresql_database_{{ svr_name|default('localhost') }}_{{ maintenance_db }}
+        - postgres_database: {{ svr_name|default('localhost') }}_{{ maintenance_db }}
       {%- endif %}
       require:
-        - postgres_database: postgresql_database_{{ svr_name|default('localhost') }}_{{ maintenance_db }}
+        - postgres_database: {{ svr_name|default('localhost') }}_{{ maintenance_db }}
 {%- endfor %}
 {%- endif %}
 
@@ -100,7 +100,7 @@ postgresql_database_{{ svr_name|default('localhost') }}_{{ database_name }}_{{ n
       database_name: {{ database_name }}
     - require:
         - file: postgresql_dirs
-        - postgres_database: postgresql_database_{{ svr_name|default('localhost') }}_{{ database_name }}
+        - postgres_database: {{ svr_name|default('localhost') }}_{{ database_name }}
 
 restore_postgresql_database_{{ database_name }}:
   cmd.run:

--- a/postgresql/client.sls
+++ b/postgresql/client.sls
@@ -5,9 +5,9 @@ postgresql_client_packages:
   pkg.installed:
   - names: {{ client.pkgs }}
 
-{%- for svr_name, svr in client.get('server', {}).iteritems() %}
+{%- for svr_name, svr in client.get('server', {}).items() %}
   {%- set admin = svr.get('admin', {}) %}
-  {%- for database_name, database in svr.get('database', {}).iteritems() %}
+  {%- for database_name, database in svr.get('database', {}).items() %}
     {%- include "postgresql/_database.sls" %}
   {%- endfor %}
 {%- endfor %}

--- a/postgresql/cluster/bdr/master.sls
+++ b/postgresql/cluster/bdr/master.sls
@@ -17,7 +17,7 @@ postgresql_user_cluster_repuser:
 
 {%- set nodename = salt.grains.get('nodename') %}
 
-{%- for database_name, database in server.get('database', {}).iteritems() %}
+{%- for database_name, database in server.get('database', {}).items() %}
 bdr_group_create_{{ database_name }}:
   module.run:
     - name: postgres.psql_query

--- a/postgresql/cluster/bdr/slave.sls
+++ b/postgresql/cluster/bdr/slave.sls
@@ -17,7 +17,7 @@ postgresql_user_cluster_repuser:
 
 {%- set nodename = salt.grains.get('nodename') %}
 
-{%- for database_name, database in server.get('database', {}).iteritems() %}
+{%- for database_name, database in server.get('database', {}).items() %}
 bdr_group_join_{{ database_name }}:
   module.run:
     - name: postgres.psql_query

--- a/postgresql/files/collectd.conf
+++ b/postgresql/files/collectd.conf
@@ -23,7 +23,7 @@ LoadPlugin postgresql
       ValuesFrom "deletes"
     </Result>
   </Query>
-  {%- for database_name, database in server.get('database', {}).iteritems() %}
+  {%- for database_name, database in server.get('database', {}).items() %}
   <Database {{ database_name }}>
     Host "{{ system.name }}.{{ system.domain }}"
     Port 5432

--- a/postgresql/files/pgpass
+++ b/postgresql/files/pgpass
@@ -3,13 +3,13 @@
 {%- for database in server.get('databases', []) %}
 {{ client }}:{{ server.bind.port }}:{{ database.name }}:{% for user in database.users %}{% if loop.first %}{{ user.name }}:{{ user.password }}{% endif %}{% endfor %}
 {%- endfor %}
-{%- for database_name, database in server.get('database', {}).iteritems() %}
+{%- for database_name, database in server.get('database', {}).items() %}
 {{ client }}:{{ server.bind.port }}:{{ database_name }}:{% for user in database.users %}{% if loop.first %}{{ user.name }}:{{ user.password }}{% endif %}{% endfor %}
 {%- endfor %}
 {%- endfor %}
 {%- for database in server.get('databases', []) %}
 localhost:{{ server.bind.port }}:{{ database.name }}:{% for user in database.users %}{% if loop.first %}{{ user.name }}:{{ user.password }}{% endif %}{% endfor %}
 {%- endfor %}
-{%- for database_name, database in server.get('database', {}).iteritems() %}
+{%- for database_name, database in server.get('database', {}).items() %}
 localhost:{{ server.bind.port }}:{{ database_name }}:{% for user in database.users %}{% if loop.first %}{{ user.name }}:{{ user.password }}{% endif %}{% endfor %}
 {%- endfor %}

--- a/postgresql/files/restore.sh
+++ b/postgresql/files/restore.sh
@@ -23,7 +23,7 @@ touch /root/postgresql/flags/{{ database.name }}-installed
 {%- endif %}
 {%- endfor %}
 
-{%- for db_name,database in pillar.postgresql.server.get("database", {}).iteritems() %}
+{%- for db_name,database in pillar.postgresql.server.get("database", {}).items() %}
 {%- if db_name == database_name %}
 
 {%- set age = database.initial_data.get("age", "0") %}

--- a/postgresql/map.jinja
+++ b/postgresql/map.jinja
@@ -5,25 +5,24 @@
     'default': '10',
 }, grain='oscodename') %}
 
-{%- set version_uni = salt['pillar.get']('postgresql:server:version', default=default_version)|string %}
-{%- set version = version_uni.encode() %}
+{%- set version = salt['pillar.get']('postgresql:server:version', default=default_version)|string %}
 {%- set version_numbers = version|replace('.', '') %}
 {%- set server = salt['grains.filter_by']({
     'Debian': {
-        'pkgs': ['postgresql-{}'.format(version), 'postgresql-contrib', 'postgresql-doc'],
-        'bdr_pkgs': ['sudo', 'postgresql-bdr-{}-bdr-plugin'.format(version), 'postgresql-bdr-{}'.format(version), 'postgresql-bdr-client-{}'.format(version), 'postgresql-bdr-contrib-{}'.format(version)],
+        'pkgs': ['postgresql-{:s}'.format(version), 'postgresql-contrib', 'postgresql-doc'],
+        'bdr_pkgs': ['sudo', 'postgresql-bdr-{:s}-bdr-plugin'.format(version), 'postgresql-bdr-{:s}'.format(version), 'postgresql-bdr-client-{:s}'.format(version), 'postgresql-bdr-contrib-{:s}'.format(version)],
         'service': 'postgresql',
         'version': version,
-        'init_command': 'pg_createcluster {} main --start'.format(version),
+        'init_command': 'pg_createcluster {:s} main --start'.format(version),
         'dir': {
-          'config': '/etc/postgresql/{}/main'.format(version),
-          'data': '/var/lib/postgresql/{}/main'.format(version)
+          'config': '/etc/postgresql/{:s}/main'.format(version),
+          'data': '/var/lib/postgresql/{:s}/main'.format(version)
         },
         'gis': False,
     },
     'RedHat': {
         'pkgs': ['postgresql93-server', 'postgresql93-contrib'],
-        'service': 'postgresql-{}'.format(version),
+        'service': 'postgresql-{:s}'.format(version),
         'version': version,
         'init_command': 'service postgresql-9.3 initdb',
         'dir': {
@@ -39,10 +38,10 @@
         'pkgs': [],
         'service': 'postgresql',
         'version': version,
-        'init_command': 'pg_createcluster {} main --start'.format(version),
+        'init_command': 'pg_createcluster {:s} main --start'.format(version),
         'dir': {
-          'config': '/etc/postgresql/{}/main'.format(version),
-          'data': '/var/lib/postgresql/{}/main'.format(version)
+          'config': '/etc/postgresql/{:s}/main'.format(version),
+          'data': '/var/lib/postgresql/{:s}/main'.format(version)
         },
         'archive': "off",
         'synchronous': False,

--- a/postgresql/map.jinja
+++ b/postgresql/map.jinja
@@ -10,20 +10,20 @@
 {%- set version_numbers = version|replace('.', '') %}
 {%- set server = salt['grains.filter_by']({
     'Debian': {
-        'pkgs': ['postgresql-' + version, 'postgresql-contrib', 'postgresql-doc'],
-        'bdr_pkgs': ['sudo', 'postgresql-bdr-' + version + '-bdr-plugin', 'postgresql-bdr-' + version, 'postgresql-bdr-client-' + version, 'postgresql-bdr-contrib-' + version],
+        'pkgs': ['postgresql-{}'.format(version), 'postgresql-contrib', 'postgresql-doc'],
+        'bdr_pkgs': ['sudo', 'postgresql-bdr-{}-bdr-plugin'.format(version), 'postgresql-bdr-{}'.format(version), 'postgresql-bdr-client-{}'.format(version), 'postgresql-bdr-contrib-{}'.format(version)],
         'service': 'postgresql',
         'version': version,
-        'init_command': 'pg_createcluster ' + version + ' main --start',
+        'init_command': 'pg_createcluster {} main --start'.format(version),
         'dir': {
-          'config': '/etc/postgresql/' + version + '/main',
-          'data': '/var/lib/postgresql/' + version + '/main'
+          'config': '/etc/postgresql/{}/main'.format(version),
+          'data': '/var/lib/postgresql/{}/main'.format(version)
         },
         'gis': False,
     },
     'RedHat': {
         'pkgs': ['postgresql93-server', 'postgresql93-contrib'],
-        'service': 'postgresql-' + version,
+        'service': 'postgresql-{}'.format(version),
         'version': version,
         'init_command': 'service postgresql-9.3 initdb',
         'dir': {
@@ -39,10 +39,10 @@
         'pkgs': [],
         'service': 'postgresql',
         'version': version,
-        'init_command': 'pg_createcluster ' + version + ' main --start',
+        'init_command': 'pg_createcluster {} main --start'.format(version),
         'dir': {
-          'config': '/etc/postgresql/' + version + '/main',
-          'data': '/var/lib/postgresql/' + version + '/main'
+          'config': '/etc/postgresql/{}/main'.format(version),
+          'data': '/var/lib/postgresql/{}/main'.format(version)
         },
         'archive': "off",
         'synchronous': False,

--- a/postgresql/server.sls
+++ b/postgresql/server.sls
@@ -87,12 +87,12 @@ database_{{ database_name }}_{{ extension_name }}_extension_present:
   - onlyif: /bin/false
   {%- endif %}
   - require:
-    - postgres_database: postgresql_database_{{ database_name }}
+    - postgres_database: {{ database_name }}
 
     {%- else %}
 
 database_{{ database_name }}_{{ extension_name }}_extension_absent:
-  postgres_extension.present:
+  postgres_extension.absent:
   - name: {{ extension_name }}
   - maintenance_db: {{ database_name }}
   - user: postgres
@@ -100,7 +100,7 @@ database_{{ database_name }}_{{ extension_name }}_extension_absent:
   - onlyif: /bin/false
   {%- endif %}
   - require:
-    - postgres_database: postgresql_database_{{ database_name }}
+    - postgres_database: {{ database_name }}
 
     {%- endif %}
   {%- endfor %}

--- a/postgresql/server.sls
+++ b/postgresql/server.sls
@@ -65,10 +65,10 @@ postgresql_service:
   - require:
     - file: /root/.pgpass
 
-{%- for database_name, database in server.get('database', {}).iteritems() %}
+{%- for database_name, database in server.get('database', {}).items() %}
   {%- include "postgresql/_database.sls" %}
 
-  {%- for extension_name, extension in database.get('extension', {}).iteritems() %}
+  {%- for extension_name, extension in database.get('extension', {}).items() %}
     {%- if extension.enabled %}
     {%- if extension.get('pkgs', []) %}
 

--- a/postgresql/server.sls
+++ b/postgresql/server.sls
@@ -74,7 +74,7 @@ postgresql_service:
 
 postgresql_{{ extension_name }}_extension_packages:
   pkg.installed:
-  - names: {{ pkgs }}
+  - names: {{ extension.get('pkgs', []) }}
 
     {%- endif %}
 


### PR DESCRIPTION
I needed to make those changes to get the formula working properly with Salt master 2019.2.0 on Ubuntu 18.04.2 LTS (which uses Python 3 by default).