### PR TITLE
Allow server locale to be overridden from pillar

### DIFF
--- a/postgresql/files/10/postgresql.conf.Debian
+++ b/postgresql/files/10/postgresql.conf.Debian
@@ -597,11 +597,11 @@ timezone = 'localtime'
 					# encoding
 
 # These settings are initialized by initdb, but they can be changed.
-lc_messages = 'en_US.UTF-8'			# locale for system error message
+lc_messages = '{{ server.locale }}'			# locale for system error message
 					# strings
-lc_monetary = 'en_US.UTF-8'			# locale for monetary formatting
-lc_numeric = 'en_US.UTF-8'			# locale for number formatting
-lc_time = 'en_US.UTF-8'				# locale for time formatting
+lc_monetary = '{{ server.locale }}'			# locale for monetary formatting
+lc_numeric = '{{ server.locale }}'			# locale for number formatting
+lc_time = '{{ server.locale }}'				# locale for time formatting
 
 # default configuration for text search
 default_text_search_config = 'pg_catalog.english'

--- a/postgresql/files/11/postgresql.conf.Debian
+++ b/postgresql/files/11/postgresql.conf.Debian
@@ -621,11 +621,11 @@ timezone = 'localtime'
 					# encoding
 
 # These settings are initialized by initdb, but they can be changed.
-lc_messages = 'en_US.UTF-8'			# locale for system error message
+lc_messages = '{{ server.locale }}'			# locale for system error message
 					# strings
-lc_monetary = 'en_US.UTF-8'			# locale for monetary formatting
-lc_numeric = 'en_US.UTF-8'			# locale for number formatting
-lc_time = 'en_US.UTF-8'				# locale for time formatting
+lc_monetary = '{{ server.locale }}'			# locale for monetary formatting
+lc_numeric = '{{ server.locale }}'			# locale for number formatting
+lc_time = '{{ server.locale }}'				# locale for time formatting
 
 # default configuration for text search
 default_text_search_config = 'pg_catalog.english'

--- a/postgresql/files/8.4/postgresql.conf.Debian
+++ b/postgresql/files/8.4/postgresql.conf.Debian
@@ -499,11 +499,11 @@ datestyle = 'iso, mdy'
 					# encoding
 
 # These settings are initialized by initdb, but they can be changed.
-lc_messages = 'en_US.UTF-8'			# locale for system error message
+lc_messages = '{{ server.locale }}'			# locale for system error message
 					# strings
-lc_monetary = 'en_US.UTF-8'			# locale for monetary formatting
-lc_numeric = 'en_US.UTF-8'			# locale for number formatting
-lc_time = 'en_US.UTF-8'				# locale for time formatting
+lc_monetary = '{{ server.locale }}'			# locale for monetary formatting
+lc_numeric = '{{ server.locale }}'			# locale for number formatting
+lc_time = '{{ server.locale }}'				# locale for time formatting
 
 # default configuration for text search
 default_text_search_config = 'pg_catalog.english'

--- a/postgresql/files/8.4/postgresql.conf.RedHat
+++ b/postgresql/files/8.4/postgresql.conf.RedHat
@@ -454,11 +454,11 @@ datestyle = 'iso, mdy'
 					# encoding
 
 # These settings are initialized by initdb, but they can be changed.
-lc_messages = 'en_US.UTF-8'			# locale for system error message
+lc_messages = '{{ server.locale }}'			# locale for system error message
 					# strings
-lc_monetary = 'en_US.UTF-8'			# locale for monetary formatting
-lc_numeric = 'en_US.UTF-8'			# locale for number formatting
-lc_time = 'en_US.UTF-8'				# locale for time formatting
+lc_monetary = '{{ server.locale }}'			# locale for monetary formatting
+lc_numeric = '{{ server.locale }}'			# locale for number formatting
+lc_time = '{{ server.locale }}'				# locale for time formatting
 
 # default configuration for text search
 default_text_search_config = 'pg_catalog.english'

--- a/postgresql/files/9.1/postgresql.conf.Debian
+++ b/postgresql/files/9.1/postgresql.conf.Debian
@@ -499,11 +499,11 @@ datestyle = 'iso, mdy'
 					# encoding
 
 # These settings are initialized by initdb, but they can be changed.
-lc_messages = 'en_US.UTF-8'			# locale for system error message
+lc_messages = '{{ server.locale }}'			# locale for system error message
 					# strings
-lc_monetary = 'en_US.UTF-8'			# locale for monetary formatting
-lc_numeric = 'en_US.UTF-8'			# locale for number formatting
-lc_time = 'en_US.UTF-8'				# locale for time formatting
+lc_monetary = '{{ server.locale }}'			# locale for monetary formatting
+lc_numeric = '{{ server.locale }}'			# locale for number formatting
+lc_time = '{{ server.locale }}'				# locale for time formatting
 
 # default configuration for text search
 default_text_search_config = 'pg_catalog.english'

--- a/postgresql/files/9.3/postgresql.conf.Debian
+++ b/postgresql/files/9.3/postgresql.conf.Debian
@@ -520,11 +520,11 @@ timezone = 'localtime'
 					# encoding
 
 # These settings are initialized by initdb, but they can be changed.
-lc_messages = 'en_US.UTF-8'			# locale for system error message
+lc_messages = '{{ server.locale }}'			# locale for system error message
 					# strings
-lc_monetary = 'en_US.UTF-8'			# locale for monetary formatting
-lc_numeric = 'en_US.UTF-8'			# locale for number formatting
-lc_time = 'en_US.UTF-8'				# locale for time formatting
+lc_monetary = '{{ server.locale }}'			# locale for monetary formatting
+lc_numeric = '{{ server.locale }}'			# locale for number formatting
+lc_time = '{{ server.locale }}'				# locale for time formatting
 
 # default configuration for text search
 default_text_search_config = 'pg_catalog.english'

--- a/postgresql/files/9.4/postgresql.conf.Debian
+++ b/postgresql/files/9.4/postgresql.conf.Debian
@@ -550,11 +550,11 @@ timezone = 'localtime'
                                         # encoding
 
 # These settings are initialized by initdb, but they can be changed.
-lc_messages = 'en_US.UTF-8'                     # locale for system error message
+lc_messages = '{{ server.locale }}'                     # locale for system error message
                                         # strings
-lc_monetary = 'en_US.UTF-8'                     # locale for monetary formatting
-lc_numeric = 'en_US.UTF-8'                      # locale for number formatting
-lc_time = 'en_US.UTF-8'                         # locale for time formatting
+lc_monetary = '{{ server.locale }}'                     # locale for monetary formatting
+lc_numeric = '{{ server.locale }}'                      # locale for number formatting
+lc_time = '{{ server.locale }}'                         # locale for time formatting
 
 # default configuration for text search
 default_text_search_config = 'pg_catalog.english'

--- a/postgresql/files/9.5/postgresql.conf.Debian
+++ b/postgresql/files/9.5/postgresql.conf.Debian
@@ -570,11 +570,11 @@ timezone = 'UTC'
 					# encoding
 
 # These settings are initialized by initdb, but they can be changed.
-lc_messages = 'en_US.UTF-8'			# locale for system error message
+lc_messages = '{{ server.locale }}'			# locale for system error message
 					# strings
-lc_monetary = 'en_US.UTF-8'			# locale for monetary formatting
-lc_numeric = 'en_US.UTF-8'			# locale for number formatting
-lc_time = 'en_US.UTF-8'				# locale for time formatting
+lc_monetary = '{{ server.locale }}'			# locale for monetary formatting
+lc_numeric = '{{ server.locale }}'			# locale for number formatting
+lc_time = '{{ server.locale }}'				# locale for time formatting
 
 # default configuration for text search
 default_text_search_config = 'pg_catalog.english'

--- a/postgresql/files/9.6/postgresql.conf.Debian
+++ b/postgresql/files/9.6/postgresql.conf.Debian
@@ -590,11 +590,11 @@ timezone = 'localtime'
                          # encoding
 
 # These settings are initialized by initdb, but they can be changed.
-lc_messages = 'en_US.UTF-8'             # locale for system error message
+lc_messages = '{{ server.locale }}'             # locale for system error message
                          # strings
-lc_monetary = 'en_US.UTF-8'             # locale for monetary formatting
-lc_numeric = 'en_US.UTF-8'              # locale for number formatting
-lc_time = 'en_US.UTF-8'                 # locale for time formatting
+lc_monetary = '{{ server.locale }}'             # locale for monetary formatting
+lc_numeric = '{{ server.locale }}'              # locale for number formatting
+lc_time = '{{ server.locale }}'                 # locale for time formatting
 
 # default configuration for text search
 default_text_search_config = 'pg_catalog.english'

--- a/postgresql/map.jinja
+++ b/postgresql/map.jinja
@@ -20,6 +20,7 @@
           'data': '/var/lib/postgresql/{:s}/main'.format(version)
         },
         'gis': False,
+        'locale': 'en_US.UTF-8',
     },
     'RedHat': {
         'pkgs': ['postgresql93-server', 'postgresql93-contrib'],
@@ -30,6 +31,7 @@
           'config': '/var/lib/pgsql/9.3/data'
         },
         'gis': False,
+        'locale': 'en_US.UTF-8',
     },
 }, merge=salt['pillar.get']('postgresql:server')) %}
 


### PR DESCRIPTION
Server locale - as controlled by the lc_* configuration items -  is set in the postgresql.conf files in this formula. Specifically, it's set to en_US.UTF-8. If the package is installed without salt, this value would be initialised from the server environment. 

This PR adds the ability to set the lc_* configuration items to a value from pillar: "postgresql:server:locale". The default value remains en_US.UTF-8, so there's no change of behaviour if the pillar key is not set.