### PR TITLE
Allow SSL files to be overriden from pillar

### DIFF
--- a/postgresql/files/10/postgresql.conf.Debian
+++ b/postgresql/files/10/postgresql.conf.Debian
@@ -79,13 +79,19 @@ unix_socket_directories = '/var/run/postgresql'	# comma-separated list of direct
 
 #authentication_timeout = 1min		# 1s-600s
 ssl = on
+{% if server.ssl_ca_file is defined -%}
+ssl_ca_file = '{{ server.ssl_ca_file }}'
+{% endif -%}
+{% if server.ssl_cert_file is defined -%}
+ssl_cert_file = '{{ server.ssl_cert_file }}'
+{% endif -%}
+{% if server.ssl_key_file is defined -%}
+ssl_key_file = '{{ server.ssl_key_file }}'
+{% endif -%}
 #ssl_ciphers = 'HIGH:MEDIUM:+3DES:!aNULL' # allowed SSL ciphers
 #ssl_prefer_server_ciphers = on
 #ssl_ecdh_curve = 'prime256v1'
 #ssl_dh_params_file = ''
-ssl_cert_file = '/etc/ssl/certs/ssl-cert-snakeoil.pem'
-ssl_key_file = '/etc/ssl/private/ssl-cert-snakeoil.key'
-#ssl_ca_file = ''
 #ssl_crl_file = ''
 #password_encryption = md5		# md5 or scram-sha-256
 #db_user_namespace = off

--- a/postgresql/files/10/postgresql.conf.RedHat
+++ b/postgresql/files/10/postgresql.conf.RedHat
@@ -17,9 +17,9 @@
 #
 # This file is read on server startup and when the server receives a SIGHUP
 # signal.  If you edit the file on a running system, you have to SIGHUP the
-# server for the changes to take effect, or use "pg_ctl reload".  Some
-# parameters, which are marked below, require a server shutdown and restart to
-# take effect.
+# server for the changes to take effect, run "pg_ctl reload", or execute
+# "SELECT pg_reload_conf()".  Some parameters, which are marked below,
+# require a server shutdown and restart to take effect.
 #
 # Any parameter can also be given as a command-line option to the server, e.g.,
 # "postgres -c log_connections=on".  Some parameters can be changed at run time
@@ -39,15 +39,15 @@
 # The default values of these variables are driven from the -D command-line
 # option or PGDATA environment variable, represented here as ConfigDir.
 
-data_directory = '/var/lib/postgresql/9.5/main'		# use data in another directory
+data_directory = '{{ server.dir.data }}'        # use data in another directory
 					# (change requires restart)
-hba_file = '/etc/postgresql/9.5/main/pg_hba.conf'	# host-based authentication file
+hba_file = '{{ server.dir.config }}pg_hba.conf'	# host-based authentication file
 					# (change requires restart)
-ident_file = '/etc/postgresql/9.5/main/pg_ident.conf'	# ident configuration file
+ident_file = '{{ server.dir.config }}pg_ident.conf'	# ident configuration file
 					# (change requires restart)
 
 # If external_pid_file is not explicitly set, no extra PID file is written.
-external_pid_file = '/var/run/postgresql/9.5-main.pid'			# write an extra PID file
+external_pid_file = '/var/run/postgresql/10-main.pid'			# write an extra PID file
 					# (change requires restart)
 
 
@@ -59,14 +59,10 @@ external_pid_file = '/var/run/postgresql/9.5-main.pid'			# write an extra PID fi
 {%- if server.bind.address == '0.0.0.0' %}
 listen_addresses = '*'
 {%- else %}
-listen_addresses = 'localhost{% if server.bind.address != '127.0.0.1' %}, {{ server.bind.address }}{% endif %}'
+listen_addresses = 'localhost{% if server.bind.address != "127.0.0.1" %}, {{ server.bind.address }}{% endif %}'
 {%- endif %}
 port = {{ server.bind.get('port', '5432') }}
-#listen_addresses = 'localhost'		# what IP address(es) to listen on;
-					# comma-separated list of addresses;
-					# defaults to 'localhost'; use '*' for all
-					# (change requires restart)
-#port = 5432				# (change requires restart)
+
 max_connections = 100			# (change requires restart)
 #superuser_reserved_connections = 3	# (change requires restart)
 unix_socket_directories = '/var/run/postgresql'	# comma-separated list of directories
@@ -82,11 +78,7 @@ unix_socket_directories = '/var/run/postgresql'	# comma-separated list of direct
 # - Security and Authentication -
 
 #authentication_timeout = 1min		# 1s-600s
-ssl = true				# (change requires restart)
-#ssl_ciphers = 'HIGH:MEDIUM:+3DES:!aNULL' # allowed SSL ciphers
-					# (change requires restart)
-#ssl_prefer_server_ciphers = on		# (change requires restart)
-#ssl_ecdh_curve = 'prime256v1'		# (change requires restart)
+ssl = on
 {% if server.ssl_ca_file is defined -%}
 ssl_ca_file = '{{ server.ssl_ca_file }}'
 {% endif -%}
@@ -96,8 +88,12 @@ ssl_cert_file = '{{ server.ssl_cert_file }}'
 {% if server.ssl_key_file is defined -%}
 ssl_key_file = '{{ server.ssl_key_file }}'
 {% endif -%}
-#ssl_crl_file = ''			# (change requires restart)
-#password_encryption = on
+#ssl_ciphers = 'HIGH:MEDIUM:+3DES:!aNULL' # allowed SSL ciphers
+#ssl_prefer_server_ciphers = on
+#ssl_ecdh_curve = 'prime256v1'
+#ssl_dh_params_file = ''
+#ssl_crl_file = ''
+#password_encryption = md5		# md5 or scram-sha-256
 #db_user_namespace = off
 #row_security = on
 
@@ -133,6 +129,7 @@ shared_buffers = 128MB			# min 128kB
 # you actively intend to use prepared transactions.
 #work_mem = 4MB				# min 64kB
 #maintenance_work_mem = 64MB		# min 1MB
+#replacement_sort_tuples = 150000	# limits use of replacement selection sort
 #autovacuum_work_mem = -1		# min 1MB, or -1 to use maintenance_work_mem
 #max_stack_depth = 2MB			# min 100kB
 dynamic_shared_memory_type = posix	# the default is the first option
@@ -142,10 +139,11 @@ dynamic_shared_memory_type = posix	# the default is the first option
 					#   windows
 					#   mmap
 					# use none to disable dynamic shared memory
+					# (change requires restart)
 
 # - Disk -
 
-#temp_file_limit = -1			# limits per-session temp file space
+#temp_file_limit = -1			# limits per-process temp file space
 					# in kB, or -1 for no limit
 
 # - Kernel Resource Usage -
@@ -166,12 +164,19 @@ dynamic_shared_memory_type = posix	# the default is the first option
 
 #bgwriter_delay = 200ms			# 10-10000ms between rounds
 #bgwriter_lru_maxpages = 100		# 0-1000 max buffers written/round
-#bgwriter_lru_multiplier = 2.0		# 0-10.0 multipler on buffers scanned/round
+#bgwriter_lru_multiplier = 2.0		# 0-10.0 multiplier on buffers scanned/round
+#bgwriter_flush_after = 512kB		# measured in pages, 0 disables
 
 # - Asynchronous Behavior -
 
 #effective_io_concurrency = 1		# 1-1000; 0 disables prefetching
-#max_worker_processes = 8
+#max_worker_processes = 8		# (change requires restart)
+#max_parallel_workers_per_gather = 2	# taken from max_parallel_workers
+#max_parallel_workers = 8		# maximum number of max_worker_processes that
+					# can be used in parallel queries
+#old_snapshot_threshold = -1		# 1min-60d; -1 disables; 0 is immediate
+					# (change requires restart)
+#backend_flush_after = 0		# measured in pages, 0 disables
 
 
 #------------------------------------------------------------------------------
@@ -180,11 +185,13 @@ dynamic_shared_memory_type = posix	# the default is the first option
 
 # - Settings -
 
-#wal_level = minimal			# minimal, archive, hot_standby, or logical
+#wal_level = replica			# minimal, replica, or logical
 					# (change requires restart)
-#fsync = on				# turns forced synchronization on or off
+#fsync = on				# flush data to disk for crash safety
+					# (turning this off can cause
+					# unrecoverable data corruption)
 #synchronous_commit = on		# synchronization level;
-					# off, local, remote_write, or on
+					# off, local, remote_write, remote_apply, or on
 #wal_sync_method = fsync		# the default is the first option
 					# supported by the operating system:
 					#   open_datasync
@@ -199,16 +206,18 @@ dynamic_shared_memory_type = posix	# the default is the first option
 #wal_buffers = -1			# min 32kB, -1 sets based on shared_buffers
 					# (change requires restart)
 #wal_writer_delay = 200ms		# 1-10000 milliseconds
+#wal_writer_flush_after = 1MB		# measured in pages, 0 disables
 
 #commit_delay = 0			# range 0-100000, in microseconds
 #commit_siblings = 5			# range 1-1000
 
 # - Checkpoints -
 
-#checkpoint_timeout = 5min		# range 30s-1h
+#checkpoint_timeout = 5min		# range 30s-1d
 #max_wal_size = 1GB
 #min_wal_size = 80MB
 #checkpoint_completion_target = 0.5	# checkpoint target duration, 0.0 - 1.0
+#checkpoint_flush_after = 256kB		# measured in pages, 0 disables
 #checkpoint_warning = 30s		# 0 disables
 
 # - Archiving -
@@ -229,32 +238,31 @@ dynamic_shared_memory_type = posix	# the default is the first option
 
 # - Sending Server(s) -
 
-# Set these on the master and on any standby that will send replication data.
-
-{%- if cluster.get('enabled', False) %}
-
-{%- if cluster.role != "master" %}
+{%- if cluster.enabled and cluster.get("mode") == "hot_standby" and cluster.role != "master" %}
 hot_standby = on
 {%- endif %}
 
-{%- if cluster.role == "master" %}
+{%- if cluster.enabled and cluster.get("mode") == "hot_standby" and cluster.role == "master" %}
+
 wal_level = hot_standby
 archive_mode = {{ cluster.archive }}
+
 max_wal_senders = {{ cluster.members|length + 1 }}
 max_replication_slots = {{ cluster.members|length + 1 }}
+
 {%- if cluster.synchronous %}
 synchronous_standby_names = '*'
 {%- endif %}
 {%- endif %}
 
-{%- endif %}
+# Set these on the master and on any standby that will send replication data.
 
-#max_wal_senders = 0		# max number of walsender processes
+#max_wal_senders = 10		# max number of walsender processes
 				# (change requires restart)
 #wal_keep_segments = 0		# in logfile segments, 16MB each; 0 disables
 #wal_sender_timeout = 60s	# in milliseconds; 0 disables
 
-#max_replication_slots = 0	# max number of replication slots
+#max_replication_slots = 10	# max number of replication slots
 				# (change requires restart)
 #track_commit_timestamp = off	# collect timestamp of transaction commit
 				# (change requires restart)
@@ -263,8 +271,9 @@ synchronous_standby_names = '*'
 
 # These settings are ignored on a standby server.
 
-#synchronous_standby_names = '*'	# standby servers that provide sync rep
-				# comma-separated list of application_name
+#synchronous_standby_names = ''	# standby servers that provide sync rep
+				# method to choose sync standbys, number of sync standbys,
+				# and comma-separated list of application_name
 				# from standby(s); '*' = all
 #vacuum_defer_cleanup_age = 0	# number of xacts by which cleanup is delayed
 
@@ -272,7 +281,7 @@ synchronous_standby_names = '*'
 
 # These settings are ignored on a master server.
 
-#hot_standby = off			# "on" allows queries during recovery
+#hot_standby = on			# "off" disallows queries during recovery
 					# (change requires restart)
 #max_standby_archive_delay = 30s	# max delay before canceling queries
 					# when reading WAL from archive;
@@ -289,6 +298,14 @@ synchronous_standby_names = '*'
 					# in milliseconds; 0 disables
 #wal_retrieve_retry_interval = 5s	# time to wait before retrying to
 					# retrieve WAL after a failed attempt
+
+# - Subscribers -
+
+# These settings are ignored on a publisher.
+
+#max_logical_replication_workers = 4	# taken from max_worker_processes
+					# (change requires restart)
+#max_sync_workers_per_subscription = 2	# taken from max_logical_replication_workers
 
 
 #------------------------------------------------------------------------------
@@ -316,6 +333,10 @@ synchronous_standby_names = '*'
 #cpu_tuple_cost = 0.01			# same scale as above
 #cpu_index_tuple_cost = 0.005		# same scale as above
 #cpu_operator_cost = 0.0025		# same scale as above
+#parallel_tuple_cost = 0.1		# same scale as above
+#parallel_setup_cost = 1000.0	# same scale as above
+#min_parallel_table_scan_size = 8MB
+#min_parallel_index_scan_size = 512kB
 #effective_cache_size = 4GB
 
 # - Genetic Query Optimizer -
@@ -336,6 +357,7 @@ synchronous_standby_names = '*'
 #from_collapse_limit = 8
 #join_collapse_limit = 8		# 1 disables collapsing of explicit
 					# JOIN clauses
+#force_parallel_mode = off
 
 
 #------------------------------------------------------------------------------
@@ -356,7 +378,7 @@ synchronous_standby_names = '*'
 					# (change requires restart)
 
 # These are only used if logging_collector is on:
-#log_directory = 'pg_log'		# directory where log files are written,
+#log_directory = 'log'			# directory where log files are written,
 					# can be absolute or relative to PGDATA
 #log_filename = 'postgresql-%Y-%m-%d_%H%M%S.log'	# log file name pattern,
 					# can include strftime() escapes
@@ -379,8 +401,11 @@ synchronous_standby_names = '*'
 # These are relevant when logging to syslog:
 #syslog_facility = 'LOCAL0'
 #syslog_ident = 'postgres'
+#syslog_sequence_numbers = on
+#syslog_split_messages = on
 
 # This is only relevant when logging to eventlog (win32):
+# (change requires restart)
 #event_source = 'PostgreSQL'
 
 # - When to Log -
@@ -442,7 +467,7 @@ synchronous_standby_names = '*'
 #log_duration = off
 #log_error_verbosity = default		# terse, default, or verbose messages
 #log_hostname = off
-log_line_prefix = '%t [%p-%l] %q%u@%d '			# special values:
+log_line_prefix = '%t [%p-%l] %q%u@%d '           # special values:
 					#   %a = application name
 					#   %u = user name
 					#   %d = database name
@@ -451,6 +476,7 @@ log_line_prefix = '%t [%p-%l] %q%u@%d '			# special values:
 					#   %p = process ID
 					#   %t = timestamp without milliseconds
 					#   %m = timestamp with milliseconds
+					#   %n = timestamp with milliseconds (as a Unix epoch)
 					#   %i = command tag
 					#   %e = SQL state
 					#   %c = session ID
@@ -468,12 +494,12 @@ log_line_prefix = '%t [%p-%l] %q%u@%d '			# special values:
 #log_temp_files = -1			# log temporary files equal or larger
 					# than the specified size in kilobytes;
 					# -1 disables, 0 logs all temp files
-log_timezone = 'UTC'
+log_timezone = 'localtime'
 
 
 # - Process Title -
 
-#cluster_name = ''			# added to process titles if nonempty
+cluster_name = '10/main'			# added to process titles if nonempty
 					# (change requires restart)
 #update_process_title = on
 
@@ -489,7 +515,7 @@ log_timezone = 'UTC'
 #track_io_timing = off
 #track_functions = none			# none, pl, all
 #track_activity_query_size = 1024	# (change requires restart)
-stats_temp_directory = '/var/run/postgresql/9.5-main.pg_stat_tmp'
+stats_temp_directory = '/var/run/postgresql/10-main.pg_stat_tmp'
 
 
 # - Statistics Monitoring -
@@ -549,6 +575,7 @@ stats_temp_directory = '/var/run/postgresql/9.5-main.pg_stat_tmp'
 #session_replication_role = 'origin'
 #statement_timeout = 0			# in milliseconds, 0 is disabled
 #lock_timeout = 0			# in milliseconds, 0 is disabled
+#idle_in_transaction_session_timeout = 0	# in milliseconds, 0 is disabled
 #vacuum_freeze_min_age = 50000000
 #vacuum_freeze_table_age = 150000000
 #vacuum_multixact_freeze_min_age = 5000000
@@ -563,7 +590,7 @@ stats_temp_directory = '/var/run/postgresql/9.5-main.pg_stat_tmp'
 
 datestyle = 'iso, mdy'
 #intervalstyle = 'postgres'
-timezone = 'UTC'
+timezone = 'localtime'
 #timezone_abbreviations = 'Default'     # Select the set of available time zone
 					# abbreviations.  Currently, there are
 					#   Default
@@ -601,6 +628,10 @@ default_text_search_config = 'pg_catalog.english'
 					# (change requires restart)
 #max_pred_locks_per_transaction = 64	# min 10
 					# (change requires restart)
+#max_pred_locks_per_relation = -2	# negative values mean
+					# (max_pred_locks_per_transaction
+					#  / -max_pred_locks_per_relation) - 1
+#max_pred_locks_per_page = 2            # min 0
 
 
 #------------------------------------------------------------------------------
@@ -616,7 +647,6 @@ default_text_search_config = 'pg_catalog.english'
 #lo_compat_privileges = off
 #operator_precedence_warning = off
 #quote_all_identifiers = off
-#sql_inheritance = on
 #standard_conforming_strings = on
 #synchronize_seqscans = on
 
@@ -640,7 +670,7 @@ default_text_search_config = 'pg_catalog.english'
 # These options allow settings to be loaded from files other than the
 # default postgresql.conf.
 
-#include_dir = 'conf.d'			# include files ending in '.conf' from
+include_dir = 'conf.d'			# include files ending in '.conf' from
 					# directory 'conf.d'
 #include_if_exists = 'exists.conf'	# include file only if it exists
 #include = 'special.conf'		# include file

--- a/postgresql/files/11/postgresql.conf.Debian
+++ b/postgresql/files/11/postgresql.conf.Debian
@@ -98,10 +98,16 @@ unix_socket_directories = '/var/run/postgresql'	# comma-separated list of direct
 # - SSL -
 
 ssl = on
-#ssl_ca_file = ''
-ssl_cert_file = '/etc/ssl/certs/ssl-cert-snakeoil.pem'
+{% if server.ssl_ca_file is defined -%}
+ssl_ca_file = '{{ server.ssl_ca_file }}'
+{% endif -%}
+{% if server.ssl_cert_file is defined -%}
+ssl_cert_file = '{{ server.ssl_cert_file }}'
+{% endif -%}
+{% if server.ssl_key_file is defined -%}
+ssl_key_file = '{{ server.ssl_key_file }}'
+{% endif -%}
 #ssl_crl_file = ''
-ssl_key_file = '/etc/ssl/private/ssl-cert-snakeoil.key'
 #ssl_ciphers = 'HIGH:MEDIUM:+3DES:!aNULL' # allowed SSL ciphers
 #ssl_prefer_server_ciphers = on
 #ssl_ecdh_curve = 'prime256v1'

--- a/postgresql/files/9.3/postgresql.conf.Debian
+++ b/postgresql/files/9.3/postgresql.conf.Debian
@@ -84,9 +84,15 @@ ssl = true				# (change requires restart)
 #ssl_ciphers = 'DEFAULT:!LOW:!EXP:!MD5:@STRENGTH'	# allowed SSL ciphers
 					# (change requires restart)
 #ssl_renegotiation_limit = 512MB	# amount of data between renegotiations
-ssl_cert_file = '/etc/ssl/certs/ssl-cert-snakeoil.pem'		# (change requires restart)
-ssl_key_file = '/etc/ssl/private/ssl-cert-snakeoil.key'		# (change requires restart)
-#ssl_ca_file = ''			# (change requires restart)
+{% if server.ssl_ca_file is defined -%}
+ssl_ca_file = '{{ server.ssl_ca_file }}'
+{% endif -%}
+{% if server.ssl_cert_file is defined -%}
+ssl_cert_file = '{{ server.ssl_cert_file }}'
+{% endif -%}
+{% if server.ssl_key_file is defined -%}
+ssl_key_file = '{{ server.ssl_key_file }}'
+{% endif -%}
 #ssl_crl_file = ''			# (change requires restart)
 #password_encryption = on
 #db_user_namespace = off

--- a/postgresql/files/9.4/postgresql.conf.Debian
+++ b/postgresql/files/9.4/postgresql.conf.Debian
@@ -84,9 +84,15 @@ ssl = true                              # (change requires restart)
 #ssl_prefer_server_ciphers = on         # (change requires restart)
 #ssl_ecdh_curve = 'prime256v1'          # (change requires restart)
 #ssl_renegotiation_limit = 0            # amount of data between renegotiations
-ssl_cert_file = '/etc/ssl/certs/ssl-cert-snakeoil.pem'          # (change requires restart)
-ssl_key_file = '/etc/ssl/private/ssl-cert-snakeoil.key'         # (change requires restart)
-#ssl_ca_file = ''                       # (change requires restart)
+{% if server.ssl_ca_file is defined -%}
+ssl_ca_file = '{{ server.ssl_ca_file }}'
+{% endif -%}
+{% if server.ssl_cert_file is defined -%}
+ssl_cert_file = '{{ server.ssl_cert_file }}'
+{% endif -%}
+{% if server.ssl_key_file is defined -%}
+ssl_key_file = '{{ server.ssl_key_file }}'
+{% endif -%}
 #ssl_crl_file = ''                      # (change requires restart)
 #password_encryption = on
 #db_user_namespace = off

--- a/postgresql/files/9.6/postgresql.conf.Debian
+++ b/postgresql/files/9.6/postgresql.conf.Debian
@@ -88,9 +88,15 @@ ssl = true                    # (change requires restart)
                          # (change requires restart)
 #ssl_prefer_server_ciphers = on         # (change requires restart)
 #ssl_ecdh_curve = 'prime256v1'          # (change requires restart)
-ssl_cert_file = '/etc/ssl/certs/ssl-cert-snakeoil.pem'      # (change requires restart)
-ssl_key_file = '/etc/ssl/private/ssl-cert-snakeoil.key'          # (change requires restart)
-#ssl_ca_file = ''             # (change requires restart)
+{% if server.ssl_ca_file is defined -%}
+ssl_ca_file = '{{ server.ssl_ca_file }}'
+{% endif -%}
+{% if server.ssl_cert_file is defined -%}
+ssl_cert_file = '{{ server.ssl_cert_file }}'
+{% endif -%}
+{% if server.ssl_key_file is defined -%}
+ssl_key_file = '{{ server.ssl_key_file }}'
+{% endif -%}
 #ssl_crl_file = ''            # (change requires restart)
 #password_encryption = on
 #db_user_namespace = off


### PR DESCRIPTION
This makes the postgresql.conf values ssl_cert_file, ssl_key_file and ssl_ca_file user-settable from pillar. Previously they had default values such as '/etc/ssl/certs/ssl-cert-snakeoil.pem'.